### PR TITLE
Fix falling from trapdoors

### DIFF
--- a/src/main/java/com/endercrest/voidspawn/MoveListener.java
+++ b/src/main/java/com/endercrest/voidspawn/MoveListener.java
@@ -1,5 +1,6 @@
 package com.endercrest.voidspawn;
 
+import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -14,8 +15,13 @@ public class MoveListener implements Listener {
     @EventHandler
     public void onMoveEvent(PlayerMoveEvent event){
         Player player = event.getPlayer();
-        if(player.getLocation().getBlock().getRelative(BlockFace.DOWN).getType().isSolid()){
+        if(player.getLocation().getBlock().getRelative(BlockFace.DOWN).getType().isSolid() && !isTrapDoor(player.getLocation().getBlock().getRelative(BlockFace.DOWN).getType())){
             TeleportManager.getInstance().setPlayerLocation(player.getUniqueId(), player.getLocation());
         }
     }
+    
+    public boolean isTrapDoor(Material mat) {
+        return (mat == Material.OAK_TRAPDOOR || mat == Material.SPRUCE_TRAPDOOR || mat == Material.BIRCH_TRAPDOOR || mat == Material.JUNGLE_TRAPDOOR || mat == Material.ACACIA_TRAPDOOR || mat == Material.DARK_OAK_TRAPDOOR || mat == Material.IRON_TRAPDOOR);
+    }    
+    
 }

--- a/src/main/java/com/endercrest/voidspawn/MoveListener.java
+++ b/src/main/java/com/endercrest/voidspawn/MoveListener.java
@@ -1,5 +1,6 @@
 package com.endercrest.voidspawn;
 
+import org.bukkit.Tag;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
@@ -15,13 +16,13 @@ public class MoveListener implements Listener {
     @EventHandler
     public void onMoveEvent(PlayerMoveEvent event){
         Player player = event.getPlayer();
-        if(player.getLocation().getBlock().getRelative(BlockFace.DOWN).getType().isSolid() && !isTrapDoor(player.getLocation().getBlock().getRelative(BlockFace.DOWN).getType())){
+        if(player.getLocation().getBlock().getRelative(BlockFace.DOWN).getType().isSolid() && !isConflictingBlock(player.getLocation().getBlock().getRelative(BlockFace.DOWN).getType())){
             TeleportManager.getInstance().setPlayerLocation(player.getUniqueId(), player.getLocation());
         }
     }
     
-    public boolean isTrapDoor(Material mat) {
-        return (mat == Material.OAK_TRAPDOOR || mat == Material.SPRUCE_TRAPDOOR || mat == Material.BIRCH_TRAPDOOR || mat == Material.JUNGLE_TRAPDOOR || mat == Material.ACACIA_TRAPDOOR || mat == Material.DARK_OAK_TRAPDOOR || mat == Material.IRON_TRAPDOOR);
+    public boolean isConflictingBlock(Material mat) {
+        return Tag.TRAPDOORS.isTagged(mat);
     }    
     
 }


### PR DESCRIPTION
If a player falls from a closed trapdor (for example in parkour), the keep falling into de void and can't stay on the block.
Already tested and working.