### PR TITLE
Update for Bentobox 1.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>world.bentobox</groupId>
             <artifactId>bentobox</artifactId>
-            <version>1.15.5</version>
+            <version>1.16.1</version>
             <scope>provided</scope>
         </dependency>
         <!-- Deprecated, but keeping for legacy purposes -->

--- a/src/main/java/com/endercrest/voidspawn/modes/island/BentoBoxIslandMode.java
+++ b/src/main/java/com/endercrest/voidspawn/modes/island/BentoBoxIslandMode.java
@@ -30,10 +30,10 @@ public class BentoBoxIslandMode extends BaseIslandMode {
         // First checks if spawn can be found in current world. If not, iterate through worlds until we find one.
         Location location;
         try {
-            location = bentoBox.getIslands().getSafeHomeLocation(world, user, 1);
+            location = bentoBox.getIslands().getSafeHomeLocation(world, user, "");
             if (location == null) {
                 for (World w: Bukkit.getWorlds()) {
-                    location = bentoBox.getIslands().getSafeHomeLocation(w, user, 1);
+                    location = bentoBox.getIslands().getSafeHomeLocation(w, user, "");
                     if (location != null) break;
                 }
             }


### PR DESCRIPTION
Bentobox 1.16.1 Introduced Home Names, instead of Home Numbers. This should support them.
(The default home is "", or "1")