### PR TITLE
Spigot Version Bump to 1.20.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.18-rc3-R0.1-SNAPSHOT</version>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Version Bumped Spigot Dependency in POM.xml to 1.20.1 from 1.18. Default plugin functionality seems to be working. No guarantees that for extra dependencies, like Bento Box.